### PR TITLE
test: expand e2e coverage for routing, navigation and links

### DIFF
--- a/.claude/skills/project-workflow/SKILL.md
+++ b/.claude/skills/project-workflow/SKILL.md
@@ -24,7 +24,36 @@ Work with GitHub in line with the repo's conventions and automation. Don't fight
 
 ## Pull requests
 
-- Target the correct base branch. Title in Conventional-Commit style; body summarizes what + why + test results. Let CI run; fix failures rather than bypassing.
+- Target the correct base branch (`develop` in this repo). Let CI run; fix failures rather than bypassing.
+- **Title:** Conventional-Commit style (`type: concise summary`), matching the branch id prefix so branch ↔ PR ↔ release stay traceable. The type drives the eventual version bump.
+
+### PR body template — always use this
+
+```markdown
+## Purpose
+
+<One or two sentences: why this PR exists — the problem it solves or the value it adds.>
+
+## Changes
+
+- <Done work item 1 — what was actually built/changed, present tense>
+- <Done work item 2>
+- <…>
+
+## Testing
+
+- <How it was verified — commands run and their result, e.g. `pnpm validate` passing, new e2e specs, manual checks. Omit section if genuinely nothing to report.>
+
+## Related
+
+<`Closes #N` for issues this PR resolves; links to related PRs/issues. Omit section if none.>
+```
+
+Guidelines:
+
+- **Purpose** and **Changes** are mandatory; **Testing** and **Related** are included whenever there's anything to report (usually there is).
+- Keep **Changes** a scannable bullet list of finished work, not a narrative — one bullet per meaningful unit of change.
+- Reference and close issues from the body via `Closes #N` so the merge auto-closes them.
 
 ## Issues / tasks (with labels & tags)
 

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
-  workers: process.env.CI ? 1 : undefined,
+  workers: process.env.CI ? 2 : undefined,
   reporter: [['html', { open: 'never' }], ['list']],
   use: {
     baseURL,

--- a/src/console-errors.e2e.ts
+++ b/src/console-errors.e2e.ts
@@ -1,0 +1,36 @@
+import { expect, test } from '@playwright/test';
+import { LANGUAGES_SHORT, PAGE_URLS } from '@shared/constants';
+
+const supportedLanguages = [LANGUAGES_SHORT.EN, LANGUAGES_SHORT.UK] as const;
+const localizedPagePaths = [
+  PAGE_URLS.HOME,
+  PAGE_URLS.EXPERIENCE,
+  PAGE_URLS.PROJECTS,
+  PAGE_URLS.CONTACTS,
+  PAGE_URLS.PRIVACY_POLICY,
+  PAGE_URLS.TERMS_AND_CONDITIONS,
+] as const;
+
+const routesToTest = supportedLanguages.flatMap((language) => localizedPagePaths.map((path) => `/${language}${path}`));
+
+test.describe('No console errors on any Astro page', () => {
+  for (const path of routesToTest) {
+    test(`logs no console or page errors on ${path}`, async ({ page }) => {
+      const errors: string[] = [];
+
+      page.on('console', (message) => {
+        if (message.type() === 'error') {
+          errors.push(`console.error: ${message.text()}`);
+        }
+      });
+      page.on('pageerror', (error) => {
+        errors.push(`pageerror: ${error.message}`);
+      });
+
+      await page.goto(path, { waitUntil: 'domcontentloaded' });
+      await page.waitForLoadState('networkidle');
+
+      expect(errors, `Console errors found on ${path}:\n${errors.join('\n')}`).toEqual([]);
+    });
+  }
+});

--- a/src/features/contacts/direct-contact/direct-contact.e2e.ts
+++ b/src/features/contacts/direct-contact/direct-contact.e2e.ts
@@ -1,0 +1,24 @@
+import { expect, test } from '@playwright/test';
+import { LANGUAGES_SHORT, PAGE_URLS, SOCIALS } from '@shared/constants';
+
+test.beforeEach(async ({ page }) => {
+  await page.goto(`/${LANGUAGES_SHORT.EN}${PAGE_URLS.CONTACTS}`, { waitUntil: 'load' });
+});
+
+test('renders a valid current Kyiv timezone offset', async ({ page }) => {
+  await expect(page.locator('#ukraine-timezone')).toHaveText(/^UTC\+[23] \((EEST|EET)\)$/);
+});
+
+test('email link opens a mailto to the configured address', async ({ page }) => {
+  const emailLink = page.getByRole('link', { name: SOCIALS.EMAIL });
+
+  await expect(emailLink).toHaveAttribute('href', `mailto:${SOCIALS.EMAIL}`);
+});
+
+test('Telegram link points to the profile and opens safely in a new tab', async ({ page }) => {
+  const telegramLink = page.getByRole('link', { name: '@khavol' });
+
+  await expect(telegramLink).toHaveAttribute('href', SOCIALS.TELEGRAM);
+  await expect(telegramLink).toHaveAttribute('target', '_blank');
+  await expect(telegramLink).toHaveAttribute('rel', 'noopener noreferrer');
+});

--- a/src/features/contacts/social-links/social-links.e2e.ts
+++ b/src/features/contacts/social-links/social-links.e2e.ts
@@ -1,0 +1,19 @@
+import { expect, test } from '@playwright/test';
+import { LANGUAGES_SHORT, PAGE_URLS, SOCIALS } from '@shared/constants';
+
+// The social cards are the only anchors on the page carrying the `card` class,
+// which keeps these assertions scoped to this section (not the footer links).
+const SOCIAL_HREFS = [SOCIALS.LINKEDIN, SOCIALS.TELEGRAM, SOCIALS.GITHUB] as const;
+
+test.beforeEach(async ({ page }) => {
+  await page.goto(`/${LANGUAGES_SHORT.EN}${PAGE_URLS.CONTACTS}`, { waitUntil: 'load' });
+});
+
+for (const href of SOCIAL_HREFS) {
+  test(`social card for ${href} opens safely in a new tab`, async ({ page }) => {
+    const card = page.locator(`a.card[href="${href}"]`);
+
+    await expect(card).toHaveAttribute('target', '_blank');
+    await expect(card).toHaveAttribute('rel', 'noopener noreferrer');
+  });
+}

--- a/src/features/layout/components/footer/footer.e2e.ts
+++ b/src/features/layout/components/footer/footer.e2e.ts
@@ -1,0 +1,30 @@
+import { expect, test } from '@playwright/test';
+import { LANGUAGES_SHORT, PAGE_URLS, SOCIALS } from '@shared/constants';
+
+const SOCIAL_HREFS = [SOCIALS.LINKEDIN, SOCIALS.TELEGRAM, SOCIALS.GITHUB] as const;
+
+test.beforeEach(async ({ page }) => {
+  await page.goto(`/${LANGUAGES_SHORT.EN}${PAGE_URLS.HOME}`, { waitUntil: 'load' });
+});
+
+for (const href of SOCIAL_HREFS) {
+  test(`footer social link for ${href} opens safely in a new tab`, async ({ page }) => {
+    const link = page.locator(`footer a[href="${href}"]`);
+
+    await expect(link).toHaveAttribute('target', '_blank');
+    await expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+  });
+}
+
+const LEGAL_LINKS = [
+  { name: 'Privacy Policy', path: PAGE_URLS.PRIVACY_POLICY },
+  { name: 'Terms & Conditions', path: PAGE_URLS.TERMS_AND_CONDITIONS },
+] as const;
+
+for (const legalLink of LEGAL_LINKS) {
+  test(`footer "${legalLink.name}" link navigates to its page`, async ({ page }) => {
+    await page.locator('footer').getByRole('link', { name: legalLink.name }).click();
+
+    await expect(page).toHaveURL(`/${LANGUAGES_SHORT.EN}${legalLink.path}`);
+  });
+}

--- a/src/features/layout/components/navbar/components/theme-selector/theme-selector.e2e.ts
+++ b/src/features/layout/components/navbar/components/theme-selector/theme-selector.e2e.ts
@@ -24,3 +24,22 @@ test('theme selector changes theme to dark and light', async ({ page }) => {
   await selectTheme(page, 'dark');
   await selectTheme(page, 'light');
 });
+
+test('theme selector follows the system preference when "system" is chosen', async ({ page }) => {
+  await page.emulateMedia({ colorScheme: 'dark' });
+  await page.goto(`/${LANGUAGES_SHORT.EN}${PAGE_URLS.HOME}`, { waitUntil: 'load' });
+
+  await page.getByRole('button', { name: THEME_TOGGLE_LABEL }).click();
+
+  const systemOption = page.locator('ul.dropdown-content button[data-set-theme="system"]').first();
+  await expect(systemOption).toBeVisible();
+  await systemOption.click();
+
+  await expect.poll(async () => page.evaluate(() => localStorage.getItem('theme'))).toBe('system');
+  await expect.poll(async () => page.locator('html').getAttribute('data-theme')).toBe('portfolio-dark');
+  await expect(page.locator('#theme-icon-system')).toBeVisible();
+
+  await page.emulateMedia({ colorScheme: 'light' });
+  await page.reload({ waitUntil: 'load' });
+  await expect.poll(async () => page.locator('html').getAttribute('data-theme')).toBe('portfolio-light');
+});

--- a/src/features/layout/components/navbar/navbar.e2e.ts
+++ b/src/features/layout/components/navbar/navbar.e2e.ts
@@ -1,0 +1,31 @@
+import { expect, test } from '@playwright/test';
+import { LANGUAGES_SHORT, PAGE_URLS } from '@shared/constants';
+
+// The horizontal nav only renders at/above the `md` breakpoint (768px), so pin a
+// desktop viewport regardless of which Playwright project runs the test.
+test.use({ viewport: { width: 1280, height: 900 } });
+
+const DESKTOP_NAV = 'nav[aria-label="Menu"]';
+
+const NAV_ITEMS = [
+  { name: 'Home', path: PAGE_URLS.HOME },
+  { name: 'Experience', path: PAGE_URLS.EXPERIENCE },
+  { name: 'Projects', path: PAGE_URLS.PROJECTS },
+  { name: 'Contacts', path: PAGE_URLS.CONTACTS },
+] as const;
+
+test('each nav link navigates to its page and is marked as the current page', async ({ page }) => {
+  await page.goto(`/${LANGUAGES_SHORT.EN}${PAGE_URLS.HOME}`, { waitUntil: 'load' });
+
+  const nav = page.locator(DESKTOP_NAV);
+
+  for (const item of NAV_ITEMS) {
+    await nav.getByRole('link', { name: `Navigate to ${item.name} page` }).click();
+
+    await expect(page).toHaveURL(`/${LANGUAGES_SHORT.EN}${item.path}`);
+
+    const activeLink = nav.getByRole('link', { name: `Navigate to ${item.name} page` });
+    await expect(activeLink).toHaveAttribute('aria-current', 'page');
+    await expect(activeLink).toHaveClass(/active/);
+  }
+});

--- a/src/features/layout/components/sidebar/sidebar.e2e.ts
+++ b/src/features/layout/components/sidebar/sidebar.e2e.ts
@@ -1,0 +1,64 @@
+import { expect, test } from '@playwright/test';
+import { LANGUAGES_SHORT, PAGE_URLS } from '@shared/constants';
+
+// The burger and drawer only exist below the `md` breakpoint (768px), so pin a
+// mobile viewport regardless of which Playwright project runs the test.
+test.use({ viewport: { width: 390, height: 844 } });
+
+const BURGER = '#mobile-drawer-burger';
+const DRAWER_TOGGLE = '#mobile-drawer';
+const CLOSE_BUTTON = '#drawer-close-btn';
+const OVERLAY = 'label.drawer-overlay';
+const DRAWER_LINKS = '#drawer-nav-list a';
+
+test.beforeEach(async ({ page }) => {
+  await page.goto(`/${LANGUAGES_SHORT.EN}${PAGE_URLS.HOME}`, { waitUntil: 'load' });
+});
+
+test('burger opens the drawer and the close button dismisses it', async ({ page }) => {
+  await page.locator(BURGER).click();
+  await expect(page.locator(DRAWER_TOGGLE)).toBeChecked();
+
+  await page.locator(CLOSE_BUTTON).click();
+  await expect(page.locator(DRAWER_TOGGLE)).not.toBeChecked();
+});
+
+test('clicking the overlay closes the drawer', async ({ page }) => {
+  await page.locator(BURGER).click();
+  await expect(page.locator(DRAWER_TOGGLE)).toBeChecked();
+
+  // The drawer menu (w-80 = 320px) sits on top of the overlay's left edge, so
+  // click the exposed region to the right of it.
+  await page.locator(OVERLAY).click({ position: { x: 360, y: 400 } });
+  await expect(page.locator(DRAWER_TOGGLE)).not.toBeChecked();
+});
+
+test('activating the burger with the keyboard opens the drawer and focuses the close button', async ({ page }) => {
+  await page.locator(BURGER).focus();
+  await page.keyboard.press('Enter');
+
+  await expect(page.locator(DRAWER_TOGGLE)).toBeChecked();
+  await expect(page.locator(CLOSE_BUTTON)).toBeFocused();
+});
+
+test('focus stays trapped between the close button and the last nav link', async ({ page }) => {
+  await page.locator(BURGER).click();
+  await expect(page.locator(DRAWER_TOGGLE)).toBeChecked();
+
+  const lastLink = page.locator(DRAWER_LINKS).last();
+
+  await lastLink.focus();
+  await page.keyboard.press('Tab');
+  await expect(page.locator(CLOSE_BUTTON)).toBeFocused();
+
+  await page.keyboard.press('Shift+Tab');
+  await expect(lastLink).toBeFocused();
+});
+
+test('a drawer nav link navigates to its page', async ({ page }) => {
+  await page.locator(BURGER).click();
+
+  await page.locator(DRAWER_LINKS, { hasText: 'Experience' }).click();
+
+  await expect(page).toHaveURL(`/${LANGUAGES_SHORT.EN}${PAGE_URLS.EXPERIENCE}`);
+});

--- a/src/features/not-found/back-buttons/back-buttons.e2e.ts
+++ b/src/features/not-found/back-buttons/back-buttons.e2e.ts
@@ -1,0 +1,28 @@
+import { expect, test } from '@playwright/test';
+import { LANGUAGES_SHORT, PAGE_URLS } from '@shared/constants';
+
+const UNKNOWN_PATH = `/${LANGUAGES_SHORT.EN}/this-route-does-not-exist`;
+
+test('an unknown route serves the 404 page', async ({ page }) => {
+  const response = await page.goto(UNKNOWN_PATH, { waitUntil: 'load' });
+
+  expect(response?.status()).toBe(404);
+  await expect(page.getByRole('heading', { name: '404' })).toBeVisible();
+});
+
+test('"Back to Home" returns to the home page', async ({ page }) => {
+  await page.goto(UNKNOWN_PATH, { waitUntil: 'load' });
+
+  await page.getByRole('link', { name: 'Back to Home' }).click();
+
+  await expect(page).toHaveURL(`/${LANGUAGES_SHORT.EN}${PAGE_URLS.HOME}`);
+});
+
+test('"Go Back" returns to the previous page in history', async ({ page }) => {
+  await page.goto(`/${LANGUAGES_SHORT.EN}${PAGE_URLS.HOME}`, { waitUntil: 'load' });
+  await page.goto(UNKNOWN_PATH, { waitUntil: 'load' });
+
+  await page.getByRole('button', { name: 'Go Back' }).click();
+
+  await expect(page).toHaveURL(`/${LANGUAGES_SHORT.EN}${PAGE_URLS.HOME}`);
+});

--- a/src/root-redirect.e2e.ts
+++ b/src/root-redirect.e2e.ts
@@ -1,0 +1,55 @@
+import { expect, test } from '@playwright/test';
+import { LANGUAGES_SHORT } from '@shared/constants';
+
+// The `/` route (src/pages/index.ts) is the only SSR route: it redirects to a
+// localized home page based on the `preferred-language` cookie / Accept-Language.
+const PREFERRED_LANGUAGE_COOKIE = 'preferred-language';
+
+const expectRedirectTo = (location: string | undefined, lang: string) => {
+  expect(location, `expected a redirect Location header`).toBeTruthy();
+  expect(location?.endsWith(`/${lang}/`), `expected ${location} to redirect to /${lang}/`).toBe(true);
+};
+
+test('redirects to English when no cookie and an English Accept-Language', async ({ request }) => {
+  const response = await request.get('/', {
+    headers: { 'accept-language': 'en-US,en;q=0.9' },
+    maxRedirects: 0,
+  });
+
+  expect(response.status(), 'expected a redirect status').toBeGreaterThanOrEqual(300);
+  expect(response.status()).toBeLessThan(400);
+  expectRedirectTo(response.headers().location, LANGUAGES_SHORT.EN);
+});
+
+test('redirects to Ukrainian when the Accept-Language prefers Ukrainian', async ({ request }) => {
+  const response = await request.get('/', {
+    headers: { 'accept-language': 'uk-UA,uk;q=0.9,en;q=0.8' },
+    maxRedirects: 0,
+  });
+
+  expectRedirectTo(response.headers().location, LANGUAGES_SHORT.UK);
+});
+
+test('preferred-language cookie wins over the Accept-Language header', async ({ request }) => {
+  const response = await request.get('/', {
+    headers: {
+      'accept-language': 'en-US,en;q=0.9',
+      cookie: `${PREFERRED_LANGUAGE_COOKIE}=${LANGUAGES_SHORT.UK}`,
+    },
+    maxRedirects: 0,
+  });
+
+  expectRedirectTo(response.headers().location, LANGUAGES_SHORT.UK);
+});
+
+test('falls back to the Accept-Language header when the cookie is not a supported language', async ({ request }) => {
+  const response = await request.get('/', {
+    headers: {
+      'accept-language': 'uk-UA,uk;q=0.9',
+      cookie: `${PREFERRED_LANGUAGE_COOKIE}=fr`,
+    },
+    maxRedirects: 0,
+  });
+
+  expectRedirectTo(response.headers().location, LANGUAGES_SHORT.UK);
+});


### PR DESCRIPTION
## Purpose

Broaden end-to-end coverage across the site's routing, navigation, and link surfaces so regressions in these behaviors are caught in CI.

## Changes

- Add e2e specs for the contacts feature: `direct-contact` and `social-links`
- Add e2e specs for layout components: `footer`, `navbar`, `sidebar`, and `theme-selector`
- Add e2e coverage for `not-found` back buttons
- Add top-level `root-redirect.e2e.ts` (root `/` → `/<lang>/` redirect) and `console-errors.e2e.ts`
- Adjust `playwright.config.ts` to support the expanded suite
- Add a reusable PR template to the `project-workflow` skill

## Testing

- `pnpm e2e` — new Playwright specs pass across the configured browser projects
- CI (build, unit, e2e, lint, type-check, CodeQL, DAST) runs on this PR
